### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,8 +4,8 @@ version = 4
 
 [[package]]
 name = "vrixyz-test-package1"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "vrixyz-test-package2"
-version = "0.1.0"
+version = "0.2.0"

--- a/crates/package1/Cargo.toml
+++ b/crates/package1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vrixyz-test-package1"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "Unlicense"
 description = "a test package for me to experiment with crates.io"

--- a/crates/package2/Cargo.toml
+++ b/crates/package2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vrixyz-test-package2"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "Unlicense"
 description = "a test package for me to experiment with crates.io"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION



## 🤖 New release

* `vrixyz-test-package1`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `vrixyz-test-package2`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `vrixyz-test-package2` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/function_missing.ron

Failed in:
  function vrixyz_test_package2::add, previously in file /tmp/.tmpr8desS/vrixyz-test-package2/src/lib.rs:1

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/module_missing.ron

Failed in:
  mod vrixyz_test_package2, previously in file /tmp/.tmpr8desS/vrixyz-test-package2/src/lib.rs:1
```

<details><summary><i><b>Changelog</b></i></summary><p>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).